### PR TITLE
switch from floa64 to Integer/Float/Num

### DIFF
--- a/enc/data_test.go
+++ b/enc/data_test.go
@@ -68,7 +68,6 @@ func testDataHelper[T any](c ctx.C, t *testing.T, in T) (jsonOut, encOut T, json
 }
 
 func TestAdvancedData(t *testing.T) {
-	t.SkipNow()
 	c := test.Context(t)
 
 	// Predefine some variables

--- a/enc/data_test.go
+++ b/enc/data_test.go
@@ -62,11 +62,13 @@ func testDataHelper[T any](c ctx.C, t *testing.T, in T) (jsonOut, encOut T, json
 	test.NoError(t, err)
 	err = enc.UnmarshalJSON(c, ej, &encOut)
 	test.NoError(t, err)
+	t.Logf("OUT: %s (%#v)", ej, encOut)
 
 	return jsonOut, encOut, jj, ej
 }
 
 func TestAdvancedData(t *testing.T) {
+	t.SkipNow()
 	c := test.Context(t)
 
 	// Predefine some variables

--- a/enc/enc.go
+++ b/enc/enc.go
@@ -1,6 +1,7 @@
 package enc
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -79,33 +80,37 @@ func fromNative(in any) Node {
 		return String(in)
 
 	case float64:
-		return Number(in)
+		return Float(in)
 	case float32:
-		return Number(in)
+		return Float(in)
 
 	case int:
-		return Number(in)
+		return Integer(in)
 	case int8:
-		return Number(in)
+		return Integer(in)
 	case int16:
-		return Number(in)
+		return Integer(in)
 	case int32:
-		return Number(in)
+		return Integer(in)
 	case int64:
-		return Number(in)
+		return Integer(in)
 	case uint:
-		return Number(in)
+		return Integer(in)
 	case uint8:
-		return Number(in)
+		return Integer(in)
 	case uint16:
-		return Number(in)
+		return Integer(in)
 	case uint32:
-		return Number(in)
+		return Integer(in)
 	case uint64:
-		return Number(in)
+		return Integer(in)
 
 	case bool:
 		return Bool(in)
+
+	case json.Number:
+		return Num(in)
+
 	default:
 		panic(fmt.Sprintf("unexpected native type %T: %+v", in, in))
 	}

--- a/enc/handler.go
+++ b/enc/handler.go
@@ -130,7 +130,7 @@ func (this Handler) unmarshal(c ctx.C, from Node, v reflect.Value) error {
 		}
 	}
 
-	log.Debugf(c, "OHA %T => %v", from, v.Type())
+	//log.Debugf(c, "OHA %T => %v", from, v.Type())
 	if this.Debugf != nil {
 		this.Debugf(c, "normal type: %v, use generic %T.unmarshalInto()", v.Type(), from)
 	}

--- a/enc/handler_test.go
+++ b/enc/handler_test.go
@@ -32,11 +32,11 @@ func TestUnmarshal(t *testing.T) {
 			map[string]any{"yes": true},
 		)
 		check(
-			enc.List{enc.Number(3.14), enc.Nil{}},
+			enc.List{enc.Float(3.14), enc.Nil{}},
 			[]any{3.14, nil},
 		)
 		check(
-			enc.Number(3.14),
+			enc.Float(3.14),
 			3.14,
 		)
 		check(
@@ -62,7 +62,7 @@ func TestUnmarshal(t *testing.T) {
 			map[string]any{"yes": true},
 		)
 		check(
-			enc.Map{"list": enc.List{enc.Nil{}, enc.Number(3.14)}},
+			enc.Map{"list": enc.List{enc.Nil{}, enc.Float(3.14)}},
 			map[string]any{"list": []any{nil, 3.14}},
 		)
 		// TODO check for error if passing not a map
@@ -75,7 +75,7 @@ func TestUnmarshal(t *testing.T) {
 		var y struct {
 			X *X `json:"x"`
 		}
-		err := h.Unmarshal(c, enc.Map{"x": enc.Map{"i": enc.Number(314)}}, &y)
+		err := h.Unmarshal(c, enc.Map{"x": enc.Map{"i": enc.Integer(314)}}, &y)
 		test.NoError(t, err)
 		test.ContainsJSON(t, y, "314")
 
@@ -114,10 +114,10 @@ func TestMarshal(t *testing.T) {
 
 	test.EqualsJSON(t, enc.Pairs{ // NOTE(oha): since we conflate a struct, we preserve the order of the fields using enc.Pairs
 		{"S", "s", enc.String("foo")},
-		{"I", "i", enc.Number(42)},
+		{"I", "i", enc.Integer(42)},
 		{"V", "v", enc.List{
 			enc.Nil{},
-			enc.Number(2),
+			enc.Integer(2),
 			enc.Bool(true),
 		}},
 	}, n)
@@ -205,7 +205,7 @@ func TestListPtrStruct(t *testing.T) {
 
 func TestArray(t *testing.T) {
 	c := test.Context(t)
-	n := enc.Number(7)
+	n := enc.Integer(7)
 	var x [2]int
 	{
 		err := enc.Unmarshal(c, enc.List{n, n}, &x)

--- a/enc/json.go
+++ b/enc/json.go
@@ -1,6 +1,7 @@
 package enc
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/Aize-Public/forego/ctx"
@@ -70,7 +71,9 @@ func mustJSON(in any) []byte {
 
 func (this JSON) Decode(c ctx.C, data []byte) (Node, error) {
 	var obj any
-	err := json.Unmarshal(data, &obj)
+	dec := json.NewDecoder(bytes.NewBuffer(data))
+	dec.UseNumber()
+	err := dec.Decode(&obj)
 	if err != nil {
 		return nil, ctx.NewErrorf(c, "%w", err)
 	}

--- a/enc/list.go
+++ b/enc/list.go
@@ -15,7 +15,8 @@ var _ Node = List{}
 func (this List) native() any {
 	out := []any{}
 	for _, n := range this {
-		out = append(out, n.native())
+		x := n.native()
+		out = append(out, x)
 	}
 	return out
 }
@@ -39,7 +40,8 @@ func (this List) String() string {
 func (this List) unmarshalInto(c ctx.C, handler Handler, into reflect.Value) error {
 	switch into.Kind() {
 	case reflect.Interface:
-		into.Set(reflect.ValueOf(this.native()))
+		x := this.native()
+		into.Set(reflect.ValueOf(x))
 		return nil
 
 	case reflect.Slice:

--- a/enc/numeric.go
+++ b/enc/numeric.go
@@ -1,0 +1,114 @@
+package enc
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/Aize-Public/forego/ctx"
+	"github.com/Aize-Public/forego/ctx/log"
+)
+
+type Numeric interface {
+	Int64() (int64, error)
+	Float64() (float64, error)
+	String() string
+}
+type numeric interface {
+	json.Marshaler
+	Numeric
+	Node
+}
+
+type Integer int
+
+var _ Node = Integer(0)
+var _ Numeric = Integer(0)
+
+func (this Integer) Int64() (int64, error)        { return int64(this), nil }
+func (this Integer) Float64() (float64, error)    { return float64(this), nil }
+func (this Integer) String() string               { return strconv.FormatInt(int64(this), 10) }
+func (this Integer) GoString() string             { return fmt.Sprintf("enc.Int{%v}", int64(this)) }
+func (this Integer) native() any                  { return int64(this) }
+func (this Integer) MarshalJSON() ([]byte, error) { return json.Marshal(int64(this)) }
+func (this Integer) unmarshalInto(c ctx.C, handler Handler, into reflect.Value) error {
+	return unmarshalNumericInto(this, c, handler, into)
+}
+
+type Float float64
+
+var _ Node = Float(0)
+var _ Numeric = Float(0)
+
+func (this Float) Int64() (int64, error)        { return int64(this), nil }
+func (this Float) Float64() (float64, error)    { return float64(this), nil }
+func (this Float) String() string               { return strconv.FormatFloat(float64(this), 'g', -1, 64) }
+func (this Float) GoString() string             { return fmt.Sprintf("enc.Float{%v}", float64(this)) }
+func (this Float) native() any                  { return float64(this) }
+func (this Float) MarshalJSON() ([]byte, error) { return json.Marshal(float64(this)) }
+func (this Float) unmarshalInto(c ctx.C, handler Handler, into reflect.Value) error {
+	return unmarshalNumericInto(this, c, handler, into)
+}
+
+type Num string
+
+var _ numeric = Num("0")
+
+func (this Num) Int64() (int64, error) {
+	i, err := strconv.ParseInt(string(this), 10, 64)
+	return i, err
+}
+func (this Num) Float64() (float64, error) { return strconv.ParseFloat(string(this), 64) }
+func (this Num) String() string            { return string(this) }
+func (this Num) GoString() string          { return fmt.Sprintf("enc.Num{%q}", string(this)) }
+
+func (this Num) native() any {
+	f, err := this.Float64() // builtin json convert to float64 when unmarshalling into any, we should do the same
+	if err == nil {
+		return f
+	}
+	return this.String()
+}
+func (this Num) MarshalJSON() ([]byte, error) { return []byte(this), nil }
+func (this Num) unmarshalInto(c ctx.C, handler Handler, into reflect.Value) error {
+	return unmarshalNumericInto(this, c, handler, into)
+}
+
+func unmarshalNumericInto(this numeric, c ctx.C, handler Handler, into reflect.Value) error {
+	log.Debugf(c, "OHA %#v => %#v", this, into)
+	switch into.Kind() {
+	case reflect.Float64, reflect.Float32:
+		f, err := this.Float64()
+		if err != nil {
+			return err
+		}
+		into.SetFloat(f)
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		i, err := this.Int64()
+		if err != nil {
+			return err
+		}
+		into.SetInt(int64(i))
+	case reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64:
+		i, err := this.Int64() // TODO FIXME need Uint
+		if err != nil {
+			return err
+		}
+		into.SetUint(uint64(i))
+	case reflect.Interface:
+		v := reflect.ValueOf(this.native())
+		into.Set(v)
+	default:
+		return ctx.NewErrorf(c, "can't unmarshal %s %T into %v", handler.path, this, into.Type())
+	}
+	return nil
+}

--- a/enc/numeric.go
+++ b/enc/numeric.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/Aize-Public/forego/ctx"
-	"github.com/Aize-Public/forego/ctx/log"
 )
 
 type Numeric interface {
@@ -76,7 +75,7 @@ func (this Num) unmarshalInto(c ctx.C, handler Handler, into reflect.Value) erro
 }
 
 func unmarshalNumericInto(this numeric, c ctx.C, handler Handler, into reflect.Value) error {
-	log.Debugf(c, "OHA %#v => %#v", this, into)
+	//log.Debugf(c, "OHA %#v => %#v", this, into)
 	switch into.Kind() {
 	case reflect.Float64, reflect.Float32:
 		f, err := this.Float64()

--- a/enc/numeric_test.go
+++ b/enc/numeric_test.go
@@ -1,0 +1,22 @@
+package enc_test
+
+import (
+	"testing"
+
+	"github.com/Aize-Public/forego/enc"
+	"github.com/Aize-Public/forego/test"
+)
+
+func TestNumeric(t *testing.T) {
+	c := test.Context(t)
+	i := int64(1000000234567890123) // big enough to be rounded as float64
+	t.Logf("i64: %d", i)
+	j := enc.MustMarshalJSON(c, i)
+	test.Contains(t, string(j), `90123`)
+	test.NoError(t, enc.UnmarshalJSON(c, j, &i))
+	test.EqualsGo(t, 1000000234567890123, i)
+	var a any
+	test.NoError(t, enc.UnmarshalJSON(c, j, &a))
+	_ = a.(float64)
+	t.Logf("a: %v", a)
+}

--- a/enc/numeric_test.go
+++ b/enc/numeric_test.go
@@ -12,7 +12,7 @@ func TestNumeric(t *testing.T) {
 	i := int64(1000000234567890123) // big enough to be rounded as float64
 	t.Logf("i64: %d", i)
 	j := enc.MustMarshalJSON(c, i)
-	test.Contains(t, string(j), `90123`)
+	test.EqualsStr(t, string(j), `1000000234567890123`)
 	test.NoError(t, enc.UnmarshalJSON(c, j, &i))
 	test.EqualsGo(t, 1000000234567890123, i)
 	var a any

--- a/enc/scalar.go
+++ b/enc/scalar.go
@@ -38,6 +38,7 @@ func (this String) unmarshalInto(c ctx.C, handler Handler, into reflect.Value) e
 	return nil
 }
 
+/*
 // NOTE(oha) do we need to split into Integers and Floats?
 type Number float64
 
@@ -79,6 +80,7 @@ func (this Number) unmarshalInto(c ctx.C, handler Handler, into reflect.Value) e
 	}
 	return nil
 }
+*/
 
 type Bool bool
 

--- a/storage/keyvalue_test.go
+++ b/storage/keyvalue_test.go
@@ -18,7 +18,7 @@ func TestKeyvalue(t *testing.T) {
 		test.Nil(t, n)
 	}
 	{
-		err := kv.Upsert(c, "one", enc.Map{"num": enc.Number(1)})
+		err := kv.Upsert(c, "one", enc.Map{"num": enc.Integer(1)})
 		test.NoError(t, err)
 	}
 	{
@@ -27,7 +27,7 @@ func TestKeyvalue(t *testing.T) {
 		test.EqualsJSON(t, `{"num":1}`, n)
 	}
 	{
-		err := kv.Upsert(c, "two", enc.Map{"num": enc.Number(2), "type": enc.String("foo")})
+		err := kv.Upsert(c, "two", enc.Map{"num": enc.Integer(2), "type": enc.String("foo")})
 		test.NoError(t, err)
 	}
 	{
@@ -38,7 +38,7 @@ func TestKeyvalue(t *testing.T) {
 	{
 		tot := 0
 		err := kv.Range(c, func(c ctx.C, k string, v enc.Map) error {
-			tot += int(v["num"].(enc.Number))
+			tot += int(v["num"].(enc.Integer))
 			return nil
 		})
 		test.NoError(t, err)

--- a/test/strings.go
+++ b/test/strings.go
@@ -16,6 +16,11 @@ func Contains(t *testing.T, str, pattern string) {
 	contains(str, pattern).true(t)
 }
 
+func ContainsGo(t *testing.T, obj any, pattern string) {
+	t.Helper()
+	contains(fmt.Sprintf("%#v", obj), pattern).true(t)
+}
+
 // check if the json of obj contains pattern
 func ContainsJSON(t *testing.T, obj any, pattern string) {
 	t.Helper()


### PR DESCRIPTION
when unmarshalling json, we UseNumeric() and then decode into enc.Num but we also ahve enc.Integer and enc.Float which can be swapped around