### PR TITLE
log+test: More generic logger using "LogFunc" and optional Helper func

### DIFF
--- a/ctx/README.md
+++ b/ctx/README.md
@@ -11,25 +11,45 @@ Just cosmetic, I find the traditional way distracting, especially when used ever
 
 ## Tags and `ctx/log`
 
-Each context has a bag of tags, which can added along the way. Those will be printed in each log message, which make them particularly useful for
-things like `CorrelationID`, `auth` or any context which will help debugging from a log message.
+Each context has a bag of tags, which can added along the way. Those will by default be added to each log message,
+which make them particularly useful for things like `CorrelationID`, `auth` or any context which will help debugging from a log message.
 
 It also make it coherent when using other libraries, since they will still carry over the context.
 
 By default, all logging is `JSONL`, e.g.:
 
-```
+```json
 {"level":"debug","src":"github.com/Aize-Public/forego/http/server.go:83","time":"2023-06-01T07:18:31.007411033+02:00","message":"listening to :8080","tags":{"service":"viewer"}}
 ```
 
 It may be wise to use a log viewer like `https://github.com/ohait/jl`
 
+
+### `slog.Logger`
+
 Alternatively, you can add your own `slog.Logger` to the context, and that one will be used instead (also in other forego libraries):
 
 ```go
 myLogger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-c = log.WithLogger(c, myLogger)
+c = log.WithSlogLogger(c, myLogger)
 log.Infof(c, "Hello world") // this will then be handled by myLogger, which in this example means it will be printed as a slog default JSON to stdout
+```
+
+
+### `LogFunc`
+
+For even more control, you can add a custom `LogFunc` instead, which will bypass the automatic logging of tags.
+Then you can also add a "Helper" function, and this example shows how that can be useful in tests:
+
+```go
+func TestSomething(t *testing.T) {
+  c = log.WithHelper(c, t.Helper) // ensures that the correct src line will be logged by t.Logf
+  c = log.WithLogFunc(c, func(c ctx.C, level slog.Level, src, f string, args ...any) {
+    t.Helper()
+    t.Logf("%s: %s", level, fmt.Sprintf(f, args...))
+  })
+  test.EqualsJSON(c, []any{1}, []int{1}) // the custom LogFunc is then passed along to the enc library via the context
+}
 ```
 
 

--- a/ctx/log/redacted_test.go
+++ b/ctx/log/redacted_test.go
@@ -11,7 +11,7 @@ import (
 func TestRedacted(t *testing.T) {
 	c := test.Context(t)
 	buf := &bytes.Buffer{}
-	c = log.WithLogger(c, log.NewDefaultLogger(buf))
+	c = log.WithSlogLogger(c, log.NewDefaultSlogLogger(buf))
 	s := log.RedactedString("foo")
 	log.Debugf(c, "redacted %s string", s)
 	test.NotContainsJSON(c, buf.String(), "foo")

--- a/ctx/tags_test.go
+++ b/ctx/tags_test.go
@@ -6,14 +6,12 @@ import (
 	"testing"
 
 	"github.com/Aize-Public/forego/ctx"
-	"github.com/Aize-Public/forego/ctx/log"
 	"github.com/Aize-Public/forego/test"
 )
 
 func TestTags(t *testing.T) {
-	var c ctx.C
-	c = context.Background()
-	c = log.WithTester(c, t)
+	c := context.Background()
+	c = test.WithTester(c, t)
 
 	fetch := func(c ctx.C) []any {
 		t.Helper()

--- a/test/README.md
+++ b/test/README.md
@@ -69,7 +69,7 @@ The simplest test, will log the argument source of the condition
 ```
 
 
-### `Equal…()` and `NotEqual…()`
+### `Equals…()` and `NotEquals…()`
 
 ```go
   test.EqualsGo(t, 123, sum(81,42)) // compare using fmt.Sprintf("%#v")

--- a/test/ctx_linux.go
+++ b/test/ctx_linux.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// NOTE: this is meant to control logging mode, but it doesn't work with go test, so consider using env instead
+// NOTE: this is meant to control logging mode, but it doesn't always work with go test ("./..."), so consider using env instead
 // this ugly thing is true if the output goes to a console, false if the output is piped somewhere
 var isTerminal = func() bool {
 	_, err := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TCGETS)

--- a/test/equals.go
+++ b/test/equals.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/Aize-Public/forego/ctx"
-	"github.com/Aize-Public/forego/ctx/log"
 	"github.com/Aize-Public/forego/utils/ast"
 )
 
@@ -59,14 +58,14 @@ func equalGo(expect, got any) res {
 
 // compare using JSON
 func EqualsJSON(c ctx.C, expect, got any) {
-	t := log.GetTester(c)
+	t := ExtractTester(c)
 	t.Helper()
 	equalJSON(c, expect, got).prefix("EqualsJSON(%s, %s)", ast.Assignment(0, 1), ast.Assignment(0, 2)).true(t)
 }
 
 // compare using JSON
 func NotEqualsJSON(c ctx.C, expect, got any) {
-	t := log.GetTester(c)
+	t := ExtractTester(c)
 	t.Helper()
 	equalJSON(c, expect, got).prefix("NotEqualsJSON(%s, %s)", ast.Assignment(0, 1), ast.Assignment(0, 2)).false(t)
 }

--- a/test/strings.go
+++ b/test/strings.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/Aize-Public/forego/ctx"
-	"github.com/Aize-Public/forego/ctx/log"
 )
 
 func NotContains(t *testing.T, str, pattern string) {
@@ -26,7 +25,7 @@ func ContainsGo(t *testing.T, obj any, pattern string) {
 
 // check if the json of obj contains pattern
 func ContainsJSON(c ctx.C, obj any, pattern string) {
-	t := log.GetTester(c)
+	t := ExtractTester(c)
 	t.Helper()
 	s := jsonish(c, obj)
 	contains(s, pattern).true(t)
@@ -34,7 +33,7 @@ func ContainsJSON(c ctx.C, obj any, pattern string) {
 
 // check if the json of obj does NOT contains pattern
 func NotContainsJSON(c ctx.C, obj any, pattern string) {
-	t := log.GetTester(c)
+	t := ExtractTester(c)
 	t.Helper()
 	s := jsonish(c, obj)
 	contains(s, pattern).false(t)


### PR DESCRIPTION
Rather than requiring a slog.Logger, logging is now done using a more generic LogFunc, while still supporing slog (wrapped in a LogFunc) and retaining the same default logging behavior. This combined with the configurable Helper func, gives the test package more control, simplifies its logging and gives it ownership of the testing.T object.